### PR TITLE
Aspects

### DIFF
--- a/src/main/java/org/education/hillel_springhomework/Aspect/LoggerAspect.java
+++ b/src/main/java/org/education/hillel_springhomework/Aspect/LoggerAspect.java
@@ -1,0 +1,71 @@
+package org.education.hillel_springhomework.Aspect;
+
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.*;
+import org.education.hillel_springhomework.dto.StatisticsCollection;
+import org.education.hillel_springhomework.model.Implementation;
+import org.education.hillel_springhomework.service.StatisticsService;
+import org.education.hillel_springhomework.writer.MyWriter;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Aspect
+@Component
+public class LoggerAspect {
+
+    private final StatisticsService statisticsService;
+    private final MyWriter myWriter;
+
+    public LoggerAspect(StatisticsService statisticsService, MyWriter myWriter) {
+        this.statisticsService = statisticsService;
+        this.myWriter = myWriter;
+    }
+
+    @Pointcut("execution(public * org.education.hillel_springhomework.repository.jpa.DataService*.*(..))")
+    public void jpaMethods() {
+    }
+
+    @Pointcut("execution(public * org.education.hillel_springhomework.repository.jdbc..*(..))")
+    public void jdbcMethods() {
+    }
+
+    @AfterReturning(pointcut = "jpaMethods()", returning = "result")
+    public void logJPA(JoinPoint joinPoint, Object result) {
+        if (result != null && !result.equals(false)) {
+            Object[] args = joinPoint.getArgs();
+            Date date = new Date();
+            String methodName = joinPoint.getSignature().getName();
+
+            myWriter.write(date, methodName, args);
+
+            StatisticsCollection statisticsCollection = new StatisticsCollection(methodName, Implementation.JPA, date);
+            statisticsService.addStatistics(statisticsCollection);
+        }
+    }
+
+    @After(value = "jdbcMethods()")
+    public void logJDBC(JoinPoint joinPoint) {
+        if (!joinPoint.getSignature().getName().equals("getUserDAO") &&
+                !joinPoint.getSignature().getName().equals("getUsers")) {
+            Object[] args = joinPoint.getArgs();
+            Date date = new Date();
+            String methodName = joinPoint.getSignature().getName();
+
+            myWriter.write(date, methodName, args);
+
+            StatisticsCollection statisticsCollection = new StatisticsCollection(methodName, Implementation.JDBC, date);
+            statisticsService.addStatistics(statisticsCollection);
+        }
+    }
+
+    @AfterThrowing(value = "jdbcMethods()", throwing = "exception")
+    public void logJDBCException(JoinPoint joinPoint, Exception exception) {
+        if (!joinPoint.getSignature().getName().equals("getUserDAO") &&
+                !joinPoint.getSignature().getName().equals("getUsers")) {
+
+            myWriter.writeException(joinPoint.getSignature().getName(), exception);
+        }
+    }
+}
+

--- a/src/main/java/org/education/hillel_springhomework/dto/StatisticsCollection.java
+++ b/src/main/java/org/education/hillel_springhomework/dto/StatisticsCollection.java
@@ -1,0 +1,38 @@
+package org.education.hillel_springhomework.dto;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.education.hillel_springhomework.model.Implementation;
+
+import java.util.Date;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@Entity
+@Table(name = "statistics")
+public class StatisticsCollection {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private int id;
+
+    @Column(name = "method")
+    private String method;
+
+    @Column(name = "implementation")
+    @Enumerated(EnumType.STRING)
+    private Implementation implementation;
+
+    @Column(name = "date")
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date date;
+
+    public StatisticsCollection(String method, Implementation implementation, Date date) {
+        this.method = method;
+        this.implementation = implementation;
+        this.date = date;
+    }
+}

--- a/src/main/java/org/education/hillel_springhomework/dto/Task.java
+++ b/src/main/java/org/education/hillel_springhomework/dto/Task.java
@@ -2,11 +2,13 @@ package org.education.hillel_springhomework.dto;
 
 import jakarta.persistence.*;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 import java.util.Calendar;
 import java.util.HashSet;
 import java.util.Set;
 
+@NoArgsConstructor
 @Entity
 @Table(name = "tasks")
 @Data
@@ -35,10 +37,6 @@ public class Task {
         this.deadline = deadLine;
         this.priority = priority;
         this.statusOfTask = statusOfTask;
-    }
-
-    public Task() {
-
     }
 
     @ManyToMany(mappedBy = "tasks")

--- a/src/main/java/org/education/hillel_springhomework/dto/User.java
+++ b/src/main/java/org/education/hillel_springhomework/dto/User.java
@@ -16,7 +16,7 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int id;
 
-    @Column(name = "name")
+    @Column(name = "name", nullable = false, unique = true)
     private String name;
 
     public User(String name, int id) {

--- a/src/main/java/org/education/hillel_springhomework/model/Implementation.java
+++ b/src/main/java/org/education/hillel_springhomework/model/Implementation.java
@@ -1,0 +1,9 @@
+package org.education.hillel_springhomework.model;
+
+import lombok.Getter;
+
+@Getter
+public enum Implementation {
+    JPA,
+    JDBC
+}

--- a/src/main/java/org/education/hillel_springhomework/repository/jpa/DataService.java
+++ b/src/main/java/org/education/hillel_springhomework/repository/jpa/DataService.java
@@ -1,0 +1,133 @@
+package org.education.hillel_springhomework.repository.jpa;
+
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.transaction.Transactional;
+import org.education.hillel_springhomework.dto.Task;
+import org.education.hillel_springhomework.dto.User;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+import java.util.Calendar;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@Transactional
+@ConditionalOnProperty(name = "implementation", havingValue = "jpa", matchIfMissing = true)
+public class DataService {
+
+    private final UserDAOJPA userDAOJPA;
+    private final TaskDAOJPA taskDAOJPA;
+
+    public DataService(UserDAOJPA userDAOJPA, TaskDAOJPA taskDAOJPA) {
+        this.userDAOJPA = userDAOJPA;
+        this.taskDAOJPA = taskDAOJPA;
+    }
+
+    //------------------Users--------------------
+    public List<User> getAllUsers() {
+        return userDAOJPA.findAll();
+    }
+
+    public User getUserById(int id) {
+        Optional<User> optionalUser = userDAOJPA.findById(id);
+        return optionalUser.orElseThrow();
+    }
+
+    public boolean addUser(User user) {
+        try {
+            userDAOJPA.save(user);
+            return true;
+        } catch (Exception e) {
+            System.err.println("Не получилось добавить пользователя: " + e.getMessage());
+            return false;
+        }
+    }
+
+    public boolean deleteUserById(int id) {
+        try {
+            userDAOJPA.deleteById(id);
+            return true;
+        } catch (Exception e) {
+            System.err.println("Не получилось удалить пользователя по id: " + e.getMessage());
+            return false;
+        }
+    }
+
+    //------------------Tasks--------------------
+    public List<Task> getAllTasks() {
+        return taskDAOJPA.findAll();
+    }
+
+    public boolean addTask(Task task) {
+        try {
+            taskDAOJPA.save(task);
+            return true;
+        } catch (Exception e) {
+            System.err.println("Не получилось добавить задачу: " + e.getMessage());
+            return false;
+        }
+    }
+
+    public List<Task> allTaskByStatus(String status) {
+        return taskDAOJPA.findAllByStatusOfTask(status);
+    }
+
+    public List<Task> allTaskByCalendar(Calendar calendar) {
+        return taskDAOJPA.findAllByDeadline(calendar);
+    }
+
+    public List<Task> allTaskByPriority(int priority) {
+        return taskDAOJPA.findAllByPriority(priority);
+    }
+
+    public boolean changeStatusOfTask(Task task, String newStatus) {
+        try {
+            taskDAOJPA.updateStatusOfTaskByStatus(task.getName(), newStatus);
+            return true;
+        } catch (Exception e) {
+            System.err.println("Не получилось изменить статус задачи: " + e.getMessage());
+            return false;
+        }
+    }
+
+    //------------------Manager_Of_Tasks--------------------
+    public boolean assignTask(User user, Task task) {
+        User tempUser = userDAOJPA.findById(user.getId()).orElseThrow(() -> new EntityNotFoundException("User not found"));
+        Task tempTask = taskDAOJPA.findById(task.getName()).orElseThrow(() -> new EntityNotFoundException("Task not found"));
+        tempUser.getTasks().add(tempTask);
+
+        try {
+            userDAOJPA.save(tempUser);
+            return true;
+        } catch (Exception e) {
+            System.err.println("Не получилось назначить задачу пользователю: " + e.getMessage());
+            return false;
+        }
+    }
+
+    public boolean changeTask(Task oldtask, Task updateTask) {
+        try {
+            taskDAOJPA.updateTask(oldtask.getName(),updateTask.getDescription(),
+                    updateTask.getDeadline(), updateTask.getPriority(), updateTask.getStatusOfTask());
+            return true;
+        } catch (Exception e) {
+            System.err.println("Не получилось изменить задачу: " + e.getMessage());
+            return false;
+        }
+    }
+
+    public boolean printAllTasksByUser(int id) {
+        List<Task> temp = taskDAOJPA.findAllTasksByUserId(id);
+        try {
+            for (Task task : temp) {
+                System.out.println(task);
+            }
+            return true;
+        } catch (Exception e) {
+            System.err.println("Не получилось вывести в консоль задачи назначенные данному пользователю:"
+                    + e.getMessage());
+            return false;
+        }
+    }
+}

--- a/src/main/java/org/education/hillel_springhomework/service/StatisticCollectionDAO.java
+++ b/src/main/java/org/education/hillel_springhomework/service/StatisticCollectionDAO.java
@@ -1,0 +1,8 @@
+package org.education.hillel_springhomework.service;
+
+import org.education.hillel_springhomework.dto.StatisticsCollection;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StatisticCollectionDAO extends JpaRepository<StatisticsCollection, Integer> {
+
+}

--- a/src/main/java/org/education/hillel_springhomework/service/StatisticsService.java
+++ b/src/main/java/org/education/hillel_springhomework/service/StatisticsService.java
@@ -1,0 +1,20 @@
+package org.education.hillel_springhomework.service;
+
+import jakarta.transaction.Transactional;
+import org.education.hillel_springhomework.dto.StatisticsCollection;
+import org.springframework.stereotype.Service;
+
+@Service
+@Transactional
+public class StatisticsService {
+
+    private final StatisticCollectionDAO statisticCollectionDAO;
+
+    public StatisticsService(StatisticCollectionDAO statisticCollectionDAO) {
+        this.statisticCollectionDAO = statisticCollectionDAO;
+    }
+
+    public void addStatistics(StatisticsCollection statistics) {
+        statisticCollectionDAO.save(statistics);
+    }
+}

--- a/src/main/java/org/education/hillel_springhomework/writer/MyWriter.java
+++ b/src/main/java/org/education/hillel_springhomework/writer/MyWriter.java
@@ -1,0 +1,65 @@
+package org.education.hillel_springhomework.writer;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Date;
+
+@Component
+public class MyWriter {
+
+    @Value("${FolderPathWriter}")
+    private String folderPath;
+
+    private File createFile() {
+        try {
+            File folder = new File(folderPath);
+            if (!folder.exists()) {
+                folder.mkdirs();
+            }
+            return folder;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void write(Date date, String methodName, Object[] args) {
+
+        File file = new File(createFile(), methodName + ".txt");
+
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(file, true))) {
+            writer.write("Method Name: " + methodName);
+            writer.newLine();
+
+            writer.write("Data: " + date);
+            writer.newLine();
+
+            for (Object arg : args) {
+                writer.write("Argument: " + arg);
+                writer.newLine();
+            }
+            writer.newLine();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void writeException(String methodName, Exception exception ) {
+        File file = new File(createFile(), methodName + ".txt");
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(file, true))) {
+             writer.write("Метод не был выполнен из-за ошибки: " + exception.getMessage());
+             writer.newLine();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}
+
+
+
+
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,4 +9,5 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 spring.jpa.show-sql=true
 spring.jpa.hibernate.ddl-auto=none
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
-implementation=jpa
+implementation=jdbc
+FolderPathWriter=src/main/resources/StatisticsArgumentWrites/


### PR DESCRIPTION
Выбрал путь записи статистики через аспекты

Крч, там у меня два разных подхода... Первый используется в JPA (при возникновении ошибки никуда ничего не пишется. Ни в БД, ни в текст файлы). Но для этого пришлось лезть руками в сам "DataService" и менять void на boolean. Иначе аспект не видит результаты выполнения "основного" метода обращения к БД (сработал-не сработал). Честно говоря, мне очень не хотелось лазить руками в Основные сервисы DAO, но ничего другого не придумал кроме как это. Создавать специальный флаг в классе и пихать его в каждый метод по сути тоже самое. Второй подход используется в JDBC и он как раз пишет все и вся в БД и в TXT файлы от независимо от результатов выполнения методов обращения к условно "основной" БД где ТАСКИ и ПОЛЬЗОВАТЕЛИ. В целом все вроде бы работает, но у меня вопрос: "Можно ли было организовать проверку результатов выполнения "основных методов" в аспектах не трогая "void" методы и вообще не трогая Сервисы DAO?". Чую что моё решение какое-то странное. И где-то должна быть возможность получить инфу о результатах там через connect к базе данных или еще как-то. Но в интернете не нашел такого способа. Мб плохо искал..."